### PR TITLE
circular_counter, flatten and garage implementation on Haskell

### DIFF
--- a/array/circular_counter/circular_counter.hs
+++ b/array/circular_counter/circular_counter.hs
@@ -1,0 +1,11 @@
+-- circular_counter :: [a] -> [a]
+circular_counter [] = []
+circular_counter [x] = [x]
+circular_counter [x,y] = [x,y]
+circular_counter xs = let ixs = zip [1..] xs
+                          (selection, remainder) = foldl (\ (s,r) p@(i,x) -> if i `mod` 3 == 0 then (p:s, r) else (s, p:r)) ([], []) ixs                                                                             
+                          lastIndex = length xs `div` 3 * 3                          
+                          (fsthalf, sndhalf) = span (\ (i, x) -> i <= lastIndex) (reverse remainder)
+                          sorted_remainder = map snd sndhalf ++ map snd fsthalf
+                        in (reverse $ map snd selection) ++ circular_counter sorted_remainder
+                        

--- a/array/flatten/flatten.hs
+++ b/array/flatten/flatten.hs
@@ -1,0 +1,10 @@
+-- needed due to Haskell's lack of heterogeneous lists
+data Tree a = Leaf a | Node [Tree a] deriving Show 
+
+input = Node [Leaf 2,Leaf 1,Node [Leaf 3,Node [Leaf 4,Leaf 5],Leaf 6],Leaf 7,Node [Leaf 8]]
+
+-- flatten
+flatten (Leaf x) = [x]
+flatten (Node xs) = concat $ map flatten xs
+
+

--- a/array/garage/garage.hs
+++ b/array/garage/garage.hs
@@ -18,8 +18,8 @@ getSteps initial final | initial == final = []
                               zeroPos = fst $ head $ filter ((==0) . snd) iInitial -- where is zero
                               idealPos = map (\x -> fst $ head $ filter ((==x) . snd) iFinal) initial -- where everyone should be                              
                               benefit = map (\i -> abs(i - (idealPos !! i)) - abs(zeroPos - (idealPos !! i))) [0..length initial-1] -- what advantage if switching places with zero
-                              minPos = fst $ head $ filter ((== (maximum benefit)) . snd) $ filter ((/=zeroPos) . fst) $ zip [0..] benefit -- the one with higher advantage, other than zero
-                              step = map (\(i,x) -> if i == zeroPos then initial !! minPos else if i == minPos then 0 else x) iInitial --swapping zero and the closer
+                              bestPos = fst $ head $ filter ((== (maximum benefit)) . snd) $ filter ((/=zeroPos) . fst) $ zip [0..] benefit -- the one with highest advantage, other than zero
+                              step = map (\(i,x) -> if i == zeroPos then initial !! bestPos else if i == bestPos then 0 else x) iInitial --swapping zero and the best
 
 
 

--- a/array/garage/garage.hs
+++ b/array/garage/garage.hs
@@ -1,0 +1,32 @@
+{-
+initial: [1, 2, 3, 0, 4]
+[0, 2, 3, 1, 4]
+[2, 0, 3, 1, 4]
+[2, 3, 0, 1, 4]
+[0, 3, 2, 1, 4]
+4
+final should be: [0, 3, 2, 1, 4]
+
+-}
+
+-- getSteps [1, 2, 3, 0, 4] [0, 3, 2, 1, 4]
+-- getSteps :: [Int] -> [Int] -> [[Int]]
+getSteps initial final | initial == final = []
+                       | otherwise = step : (getSteps step final)
+                        where iInitial = zip [0..] initial
+                              iFinal = zip [0..] final
+                              zeroPos = fst $ head $ filter ((==0) . snd) iInitial -- where is zero
+                              idealPos = map (\x -> fst $ head $ filter ((==x) . snd) iFinal) initial -- where everyone should be                              
+                              benefit = map (\i -> abs(i - (idealPos !! i)) - abs(zeroPos - (idealPos !! i))) [0..length initial-1] -- what advantage if switching places with zero
+                              minPos = fst $ head $ filter ((== (maximum benefit)) . snd) $ filter ((/=zeroPos) . fst) $ zip [0..] benefit -- the one with higher advantage, other than zero
+                              step = map (\(i,x) -> if i == zeroPos then initial !! minPos else if i == minPos then 0 else x) iInitial --swapping zero and the closer
+
+
+
+garage :: [Int] -> [Int] -> IO()
+garage initial final = do
+    putStrLn ("initial: " ++ (show initial))
+    let steps = getSteps initial final
+    sequence $ map (\x -> putStrLn $ show x) steps
+    print $ length steps
+    putStrLn ("final should be: " ++ (show final))


### PR DESCRIPTION
Implementation in Haskell of the first three problems from the "array" category, in their respective .hs files. Mutability was a problem, and the need to logically shift and swap elements from lists may possibly lead to  sub-optimal solutions.